### PR TITLE
Undefined behavior due to missing return statement

### DIFF
--- a/jsmn.cpp
+++ b/jsmn.cpp
@@ -143,6 +143,7 @@ Value& Value::operator=(const Value& other) {
   default:
     break;
   }
+  return *this;
 }
 Value::~Value() {
 }


### PR DESCRIPTION
An assignment operator was missing a return statement, causing
undefined behavior under clang+llvm, which would insert a special
undefined instruction (`ud2`) under the x86_64 architecture.

This was observed with `luoyetx/JDA`, for which this library is a dependency:

```
Current executable set to 'jda' (x86_64).
(lldb) run live
Process 56984 launched: '/Users/chris/Code/luoyetx/JDA/build/jda' (x86_64)
Process 56984 stopped
* thread #1: tid = 0xf9b691, 0x0000000100079d3d jda`jsmn::Value::operator=(this=0x0000000102803938, other=0x00007fff5fbfa230) + 253 at jsmn.cpp:147, queue = 'com.apple.main-thread', stop reason = EXC_BAD_INSTRUCTION (code=EXC_I386_INVOP, subcode=0x0)
    frame #0: 0x0000000100079d3d jda`jsmn::Value::operator=(this=0x0000000102803938, other=0x00007fff5fbfa230) + 253 at jsmn.cpp:147
   144    case jsmn::Value::NIL:
   145    default:
   146      break;
-> 147    }
   148  }
   149  Value::~Value() {
   150  }
```
